### PR TITLE
feat: implement stream messaging for task progress

### DIFF
--- a/gui_agents/maestro/controller/main_controller.py
+++ b/gui_agents/maestro/controller/main_controller.py
@@ -19,6 +19,7 @@ from PIL import Image
 
 from ..utils.screenShot import scale_screenshot_dimensions
 from ...store.registry import Registry
+from ..stream_manager import stream_manager
 
 from ..new_global_state import NewGlobalState
 from ..new_manager import NewManager
@@ -69,6 +70,8 @@ class MainController:
             self.global_state = global_state
         else:
             self.global_state = self._registry_global_state(log_dir, datetime_str)
+
+        stream_manager.register_task(self.global_state.task_id)
         
         # Basic configuration
         self.platform = platform
@@ -403,6 +406,7 @@ class MainController:
                 # 1. Check if should exit loop
                 if self.state_machine.should_exit_loop():
                     logger.info("Task fulfilled or rejected, breaking main loop")
+                    stream_manager.unregister_task(self.global_state.task_id)
                     break
 
                 # 2. Get current state

--- a/gui_agents/maestro/data_models.py
+++ b/gui_agents/maestro/data_models.py
@@ -65,6 +65,7 @@ class TaskData:
     plan_num: int = 0  # Record the number of planning attempts
     history_subtask_ids: List[str] = field(default_factory=list)
     pending_subtask_ids: List[str] = field(default_factory=list)
+    stream_messages: List[Dict[str, str]] = field(default_factory=list)
     managerComplete: bool = False
     qa_policy: Dict[str, Any] = field(default_factory=lambda: {
         "per_subtask": True,
@@ -84,6 +85,7 @@ class TaskData:
             "plan_num": self.plan_num,
             "history_subtask_ids": self.history_subtask_ids,
             "pending_subtask_ids": self.pending_subtask_ids,
+            "stream_messages": self.stream_messages[-100:],
             "managerComplete": self.managerComplete,
             "qa_policy": self.qa_policy
         }
@@ -101,6 +103,7 @@ class TaskData:
             plan_num=data.get("plan_num", 0),
             history_subtask_ids=data.get("history_subtask_ids", []),
             pending_subtask_ids=data.get("pending_subtask_ids", []),
+            stream_messages=data.get("stream_messages", []),
             managerComplete=data.get("managerComplete", False),
             qa_policy=data.get("qa_policy", {
                 "per_subtask": True,

--- a/gui_agents/maestro/stream_manager.py
+++ b/gui_agents/maestro/stream_manager.py
@@ -1,0 +1,81 @@
+import queue
+from typing import Dict, Optional, Generator
+from dataclasses import dataclass
+import logging
+
+logger = logging.getLogger(__name__)
+
+@dataclass
+class StreamMessage:
+    stage: str
+    message: str
+
+class StreamManager:
+    """
+    Manages in-memory message queues for each task to stream progress.
+
+    todo: P2 task_queues need to add mutex for thread safety
+    todo: P3 using an external message queue
+    """
+    def __init__(self, max_queue_size: int = 100):
+        self.task_queues: Dict[str, queue.Queue[Optional[StreamMessage]]] = {}
+        self.max_queue_size = max_queue_size
+
+    def add_message(self, task_id: str, stage: str, message: str):
+        """Adds a message to a task's queue. Non-blocking."""
+        if task_id in self.task_queues:
+            msg = StreamMessage(stage=stage, message=message)
+
+            try:
+                self.task_queues[task_id].put_nowait(msg)
+            except queue.Full:
+                logger.warning(f"Message queue for task {task_id} is full. Dropping oldest message.")
+                try:
+                    # Drop the oldest message to make space for the new one
+                    self.task_queues[task_id].get_nowait()
+                    self.task_queues[task_id].put_nowait(msg)
+                except queue.Empty:
+                    pass  # Should not happen if queue was full
+        else:
+            logger.warning(f"No message queue found for task {task_id}. Message not added.")
+
+    def get_message_stream(self, task_id: str) -> Generator[StreamMessage, None, None]:
+        """Returns a generator that yields messages from a task's queue. Blocks until a message is available."""
+        if task_id not in self.task_queues:
+            self.register_task(task_id)
+        
+        q = self.task_queues[task_id]
+        while True:
+            message = q.get(block=True)
+            if message is None:  # Sentinel value indicates end of stream
+                logger.info(f"End of stream for task {task_id}")
+                break
+            yield message
+
+    def register_task(self, task_id: str):
+        """Creates a new message queue for a task."""
+        if task_id not in self.task_queues:
+            self.task_queues[task_id] = queue.Queue(maxsize=self.max_queue_size)
+            logger.info(f"Registered message queue for task {task_id}")
+
+    def unregister_task(self, task_id: str):
+        """Removes a task's message queue and signals end of stream."""
+        if task_id in self.task_queues:
+            try:
+                # Put a sentinel value to unblock any consumers
+                self.task_queues[task_id].put_nowait(None)
+            except queue.Full:
+                # If full, make space for sentinel
+                try:
+                    self.task_queues[task_id].get_nowait()
+                    self.task_queues[task_id].put_nowait(None)
+                except queue.Empty:
+                    pass
+            
+            # The queue will be garbage collected after consumers are done.
+            # For immediate cleanup, we can delete it.
+            del self.task_queues[task_id]
+            logger.info(f"Unregistered message queue for task {task_id}")
+
+# Global instance to be used across the application
+stream_manager = StreamManager()


### PR DESCRIPTION
#### Summary of your change / What this PR does / why we need it?
- Add stream_messages field to TaskData model for persistent message storage
- Create StreamManager class to handle in-memory message queues per task
- Register and unregister tasks with stream manager during controller lifecycle
- Add add_stream_message method to NewGlobalState for appending messages
- Limit persistent stream_messages list to last 200 entries
- Include last100 stream messages in task data serialization
- Add stream message creation for LLM call outputs and event details
- Implement thread-safe message queue operations with size limits
- Support graceful shutdown of message streams with sentinel values

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #21 

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.

**Special notes for your reviewer**:
