### PR TITLE
refactor: restructure Lybic sandbox and auth handling

### DIFF
--- a/gui_agents/grpc_app.py
+++ b/gui_agents/grpc_app.py
@@ -270,16 +270,16 @@ class AgentServicer(agent_pb2_grpc.AgentServicer):
                 if sid:
                     logger.info(f"Using existing sandbox with id: {sid}")
                     sandbox_pb = await self._get_sandbox_pb(sid, lybic_auth)  # if not exist raise NotFound
-                    platform_str = sandbox_pb.os
+                    platform_str = platform_map.get(sandbox_pb.os, platform.system())
                 else:
                     sandbox_pb = await self._create_sandbox(shape, lybic_auth)
-                    sid, platform_str = sandbox_pb.id, sandbox_pb.os
+                    sid, platform_str = sandbox_pb.id, platform_map.get(sandbox_pb.os, platform.system())
 
                 if request.sandbox.os != agent_pb2.SandboxOS.OSUNDEFINED:
                     platform_str = platform_map.get(request.sandbox.os, platform.system())
             else:
                 sandbox_pb = await self._create_sandbox(shape, lybic_auth)
-                sid, platform_str = sandbox_pb.id, sandbox_pb.os
+                sid, platform_str = sandbox_pb.id, platform_map.get(sandbox_pb.os, platform.system())
         else:
             if request.HasField("sandbox") and request.sandbox.os != agent_pb2.SandboxOS.OSUNDEFINED:
                 platform_str = platform_map.get(request.sandbox.os, platform.system())
@@ -766,7 +766,7 @@ class AgentServicer(agent_pb2_grpc.AgentServicer):
 
         return agent_pb2.Sandbox(
             id=sandbox.sandbox.id,
-            os=self._lybic_sandbox_os_to_pb_enum(sandbox.sandbox.shape.os),
+            os=self._lybic_sandbox_os_to_pb_enum(sandbox.sandbox.shape),
             shapeName=sandbox.sandbox.shapeName,
             hardwareAcceleratedEncoding=sandbox.sandbox.shape.hardwareAcceleratedEncoding,
             virtualization=sandbox.sandbox.shape.virtualization,


### PR DESCRIPTION
#### Summary of your change / What this PR does / why we need it?
- Removed deprecated lybic_auth, lybic_client, and sandbox attributes
- Centralized Lybic authentication logic within _create_sandbox and _get_sandbox_pb methods
- Modified _create_sandbox to accept LybicAuth parameter directly
- Updated _get_sandbox_pb to use static method pattern and accept LybicAuth
- Added validation for required authorization fields when using Lybic backend
- Removed global Lybic client initialization in favor of per-operation clients
- Added proper client cleanup with close() calls after sandbox operations
- Removed obsolete sandbox field from backend_kwargs after processing
- Improved OS enum conversion with dedicated helper method
- Enhanced error handling for missing authorization information

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #43 

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.

**Special notes for your reviewer**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Authentication is now derived and validated per request instead of kept globally, improving consistency and isolation.
  * Sandbox creation and retrieval use explicit per-call auth, preventing cross-backend state leakage.
* **Bug Fixes**
  * Sandbox OS values are normalized to a consistent enum in responses, ensuring stable platform reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->