### PR TITLE
feat: enhance screenshot handling by adding URL support for Lybic bac…

### DIFF
--- a/gui_agents/agents/Backend/LybicBackend.py
+++ b/gui_agents/agents/Backend/LybicBackend.py
@@ -352,12 +352,19 @@ class LybicBackend(LybicSandboxDestroyMixin, Backend):
         try:
             url, image, b64_str = self.loop.run_until_complete(_get_screenshot())
             
+            # 存储截图URL，供后续LLM请求使用
+            self.last_screenshot_url = url
+            
             # 返回PIL图像，保持与原LybicBackend的兼容性
             # 如果需要cursor信息，可以通过其他方式获取
             return image
             
         except Exception as e:
             raise RuntimeError(f"Failed to take screenshot: {e}") from e
+    
+    def get_last_screenshot_url(self) -> Optional[str]:
+        """获取最新的截图URL"""
+        return self.last_screenshot_url
 
     def get_sandbox_id(self) -> str:
         """获取当前沙盒ID"""

--- a/gui_agents/agents/Backend/LybicMobileBackend.py
+++ b/gui_agents/agents/Backend/LybicMobileBackend.py
@@ -103,6 +103,9 @@ class LybicMobileBackend(LybicSandboxDestroyMixin, Backend):
         # 沙盒ID
         self.sandbox_id = self.precreate_sid
         
+        # 存储最新的截图URL
+        self.last_screenshot_url: Optional[str] = None
+        
         # 如果没有预创建的沙盒ID，则创建新沙盒
         if not self.sandbox_id:
             log.info("Creating sandbox using official SDK...")
@@ -342,12 +345,19 @@ class LybicMobileBackend(LybicSandboxDestroyMixin, Backend):
         try:
             url, image, b64_str = self.loop.run_until_complete(_get_screenshot())
             
+            # 存储截图URL，供后续LLM请求使用
+            self.last_screenshot_url = url
+            
             # 返回PIL图像，保持与原LybicBackend的兼容性
             # 如果需要cursor信息，可以通过其他方式获取
             return image
             
         except Exception as e:
             raise RuntimeError(f"Failed to take screenshot: {e}") from e
+    
+    def get_last_screenshot_url(self) -> Optional[str]:
+        """获取最新的截图URL"""
+        return self.last_screenshot_url
 
     def get_sandbox_id(self) -> str:
         """获取当前沙盒ID"""

--- a/gui_agents/agents/grounding.py
+++ b/gui_agents/agents/grounding.py
@@ -201,7 +201,8 @@ class Grounding(ACI, MobileActionsMixin):
         response, total_tokens, cost_string = self.grounding_model.execute_tool(
             "grounding", {
                 "str_input": prompt,
-                "img_input": obs["screenshot"]
+                "img_input": obs["screenshot"],
+                "img_url": obs.get("screenshot_url")
             })
         logger.info(
             f"Grounding model tokens: {total_tokens}, cost: {cost_string}")

--- a/gui_agents/agents/manager.py
+++ b/gui_agents/agents/manager.py
@@ -372,7 +372,12 @@ class Manager:
         # Stream subtask planning message
         self._send_stream_message(self.task_id, "planning", "Analyzing tasks and generating subtask plans...")
 
-        plan, total_tokens, cost_string = self.generator_agent.execute_tool("subtask_planner", {"str_input": generator_message, "img_input": observation.get("screenshot", None)})
+        plan, total_tokens, cost_string = self.generator_agent.execute_tool(
+            "subtask_planner", {
+                "str_input": generator_message,
+                "img_input": observation.get("screenshot", None),
+                "img_url": observation.get("screenshot_url")
+            })
         logger.info(f"Subtask planner tokens: {total_tokens}, cost: {cost_string}")
         subtask_planner_time = time.time() - subtask_planner_start
         logger.info(f"[Timing] Manager.subtask_planner execution time: {subtask_planner_time:.2f} seconds")

--- a/gui_agents/agents/worker.py
+++ b/gui_agents/agents/worker.py
@@ -285,6 +285,7 @@ class Worker:
                     text_content +
                     "\n\nThe initial screen is provided. No action has been taken yet.",
                     image_content=obs["screenshot"],
+                    image_url=obs.get("screenshot_url"),
                     role="user")
 
             else:
@@ -298,7 +299,8 @@ class Worker:
                 reflection, total_tokens, cost_string = self.reflection_agent.execute_tool(
                     "traj_reflector", {
                         "str_input": text_content,
-                        "img_input": obs["screenshot"]
+                        "img_input": obs["screenshot"],
+                        "img_url": obs.get("screenshot_url")
                     })
                 logger.info(
                     f"Trajectory reflector tokens: {total_tokens}, cost: {cost_string}"
@@ -338,7 +340,8 @@ class Worker:
             "action_generator_with_takeover"
             if self.enable_takeover else "action_generator", {
                 "str_input": generator_message,
-                "img_input": obs["screenshot"]
+                "img_input": obs["screenshot"],
+                "img_url": obs.get("screenshot_url")
             })
         logger.info(
             f"Action generator tokens: {total_tokens}, cost: {cost_string}")

--- a/gui_agents/cli_app.py
+++ b/gui_agents/cli_app.py
@@ -304,8 +304,14 @@ def run_agent_normal(agent, instruction: str, hwi_para: HardwareInterface, max_s
                 return
 
             screenshot: Image.Image = hwi.dispatch(Screenshot())  # type: ignore
+            
+            # 获取截图URL（如果是Lybic后端）
+            screenshot_url = None
+            if hasattr(hwi.backend, 'get_last_screenshot_url'):
+                screenshot_url = hwi.backend.get_last_screenshot_url()
+            
             global_state.set_screenshot(
-                scale_screenshot_dimensions(screenshot, hwi_para))  # type: ignore
+                scale_screenshot_dimensions(screenshot, hwi_para), url=screenshot_url)  # type: ignore
             obs = global_state.get_obs_for_manager()
 
             predict_start = time.time()
@@ -453,8 +459,14 @@ def run_agent_fast(agent,
                 return
 
             screenshot: Image.Image = hwi.dispatch(Screenshot())  # type: ignore
+            
+            # 获取截图URL（如果是Lybic后端）
+            screenshot_url = None
+            if hasattr(hwi.backend, 'get_last_screenshot_url'):
+                screenshot_url = hwi.backend.get_last_screenshot_url()
+            
             global_state.set_screenshot(
-                scale_screenshot_dimensions(screenshot, hwi_para))  # type: ignore
+                scale_screenshot_dimensions(screenshot, hwi_para), url=screenshot_url)  # type: ignore
             obs = global_state.get_obs_for_manager()
 
             predict_start = time.time()

--- a/gui_agents/core/mllm.py
+++ b/gui_agents/core/mllm.py
@@ -222,11 +222,21 @@ class LLMAgent:
         self,
         text_content,
         image_content=None,
+        image_url=None,
         role=None,
         image_detail="high",
         put_text_last=False,
     ):
-        """Add a new message to the list of messages"""
+        """Add a new message to the list of messages
+        
+        Args:
+            text_content: Text content of the message
+            image_content: Image data (bytes or numpy array), will be base64 encoded
+            image_url: Direct image URL (preferred over base64 for large images)
+            role: Message role
+            image_detail: Detail level for image
+            put_text_last: Whether to put text after images
+        """
 
         # API-style inference from OpenAI and similar services
         if isinstance(
@@ -263,7 +273,30 @@ class LLMAgent:
                 "content": [{"type": "text", "text": text_content}],
             }
 
-            if isinstance(image_content, np.ndarray) or image_content:
+            # 优先使用image_url（避免base64编码大图）
+            if image_url:
+                if isinstance(image_url, list):
+                    for url in image_url:
+                        message["content"].append(
+                            {
+                                "type": "image_url",
+                                "image_url": {
+                                    "url": url,
+                                  "detail": image_detail,
+                                },
+                            }
+                        )
+                else:
+                    message["content"].append(
+                        {
+                            "type": "image_url",
+                            "image_url": {
+                                "url": image_url,
+                               "detail": image_detail,
+                            },
+                        }
+                    )
+            elif isinstance(image_content, np.ndarray) or image_content:
                 # Check if image_content is a list or a single image
                 if isinstance(image_content, list):
                     # If image_content is a list of images, loop through each image
@@ -314,7 +347,30 @@ class LLMAgent:
                 "content": [{"type": "text", "text": text_content}],
             }
 
-            if image_content:
+            # 优先使用image_url（Anthropic支持URL source）
+            if image_url:
+                if isinstance(image_url, list):
+                    for url in image_url:
+                        message["content"].append(
+                            {
+                                "type": "image",
+                                "source": {
+                                    "type": "url",
+                                    "url": url,
+                                },
+                            }
+                        )
+                else:
+                    message["content"].append(
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "url",
+                                "url": image_url,
+                            },
+                        }
+                    )
+            elif image_content:
                 # Check if image_content is a list or a single image
                 if isinstance(image_content, list):
                     # If image_content is a list of images, loop through each image
@@ -361,7 +417,26 @@ class LLMAgent:
                 "content": [{"type": "text", "text": text_content}],
             }
 
-            if image_content:
+            # 优先使用image_url
+            if image_url:
+                if isinstance(image_url, list):
+                    for url in image_url:
+                        message["content"].append(
+                            {
+                                "type": "image_url",
+                                "image_url": {
+                                    "url": url
+                                },
+                            }
+                        )
+                else:
+                    message["content"].append(
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": image_url},
+                        }
+                    )
+            elif image_content:
                 # Check if image_content is a list or a single image
                 if isinstance(image_content, list):
                     # If image_content is a list of images, loop through each image

--- a/gui_agents/service/agent_service.py
+++ b/gui_agents/service/agent_service.py
@@ -317,7 +317,13 @@ class AgentService:
             for step in range(max_steps):
                 # Take screenshot
                 screenshot: Image.Image = hwi.dispatch(Screenshot())
-                global_state.set_screenshot(screenshot)
+                
+                # 获取截图URL（如果是Lybic后端）
+                screenshot_url = None
+                if hasattr(hwi.backend, 'get_last_screenshot_url'):
+                    screenshot_url = hwi.backend.get_last_screenshot_url()
+                
+                global_state.set_screenshot(screenshot, url=screenshot_url)
                 obs = global_state.get_obs_for_manager()
                 
                 # Get agent prediction
@@ -372,7 +378,13 @@ class AgentService:
             for step in range(max_steps):
                 # Take screenshot
                 screenshot: Image.Image = hwi.dispatch(Screenshot())
-                global_state.set_screenshot(screenshot)
+                
+                # 获取截图URL（如果是Lybic后端）
+                screenshot_url = None
+                if hasattr(hwi.backend, 'get_last_screenshot_url'):
+                    screenshot_url = hwi.backend.get_last_screenshot_url()
+                
+                global_state.set_screenshot(screenshot, url=screenshot_url)
                 obs = global_state.get_obs_for_manager()
                 
                 # Get agent prediction

--- a/gui_agents/tools/tools.py
+++ b/gui_agents/tools/tools.py
@@ -124,9 +124,15 @@ class BaseTool(ABC):
         # Extract text and image inputs
         text_input = input_data.get('str_input', '')
         image_input = input_data.get('img_input', None)
+        image_url = input_data.get('img_url', None)
         
         # Add the message with the formatted prompt
-        self.llm_agent.add_message(text_input, image_content=image_input, role="user")
+        self.llm_agent.add_message(
+            text_input, 
+            image_content=image_input,
+            image_url=image_url,
+            role="user"
+        )
         
         # Implement safe retry mechanism
         max_retries = 3


### PR DESCRIPTION
…kend

#### Summary of your change / What this PR does / why we need it?
This pull request introduces support for passing screenshot URLs alongside screenshot image data throughout the agent system. The main goal is to optimize image handling, especially for large images, by enabling components and LLMs to use direct URLs instead of base64-encoded data. The changes affect backend classes, global state management, CLI and service entrypoints, core LLM message formatting, and agent tool invocation.

**Backend and State Management Enhancements**
* Added `last_screenshot_url` attribute and `get_last_screenshot_url()` method to both `LybicBackend` and `LybicMobileBackend` to store and retrieve the latest screenshot URL. [[1]](diffhunk://#diff-aa2bd12671c350c777976e2ea150b9a1b7ca6a17b2aa5c4df3e440ee2cd07173R355-R368) [[2]](diffhunk://#diff-40ee1fbcccd29c0ff6a248e48887d758fc69f96c513e6a0afe9642bf9c34c7d1R106-R108) [[3]](diffhunk://#diff-40ee1fbcccd29c0ff6a248e48887d758fc69f96c513e6a0afe9642bf9c34c7d1R348-R361)
* Updated `global_state` to save and retrieve the screenshot URL, and include it in observation dictionaries for manager, grounding, and evaluator agents. [[1]](diffhunk://#diff-1a9b16598f3fcf2ac3e4a8d0a48859a0e52edc70c00cf59c180e70a3f5c9d560R183-R185) [[2]](diffhunk://#diff-1a9b16598f3fcf2ac3e4a8d0a48859a0e52edc70c00cf59c180e70a3f5c9d560L256-R284) [[3]](diffhunk://#diff-1a9b16598f3fcf2ac3e4a8d0a48859a0e52edc70c00cf59c180e70a3f5c9d560R527-R535) [[4]](diffhunk://#diff-1a9b16598f3fcf2ac3e4a8d0a48859a0e52edc70c00cf59c180e70a3f5c9d560R544)

**Entrypoint and Screenshot Handling**
* Modified CLI (`cli_app.py`) and service (`agent_service.py`) logic to fetch and provide screenshot URLs from backends when saving screenshots, ensuring URLs are available in global state for downstream usage. [[1]](diffhunk://#diff-dcab3ad0d2360d6e17c72bcabcfe68a6935d63fbca92a7f1b8741c0813258e31R307-R314) [[2]](diffhunk://#diff-dcab3ad0d2360d6e17c72bcabcfe68a6935d63fbca92a7f1b8741c0813258e31R462-R469) [[3]](diffhunk://#diff-a82a9f48cb3ed45042571736f0f1398cf16c44b6fa996feaf471b55408f03be1L320-R326) [[4]](diffhunk://#diff-a82a9f48cb3ed45042571736f0f1398cf16c44b6fa996feaf471b55408f03be1L375-R387)

**Downstream Agent and Tool Integration**
* Updated agent modules (`grounding.py`, `manager.py`, `worker.py`) to pass `img_url` in tool invocation payloads, allowing models and tools to access screenshot URLs in addition to image data. [[1]](diffhunk://#diff-716b05c141e19f0d5622e585f23908d726fea685805fedd8a94bf64333b7cd59L204-R205) [[2]](diffhunk://#diff-002a6d042577ff18e448c8180fb3777a9621c8ac9a85932f60b806b9c9aff64cL375-R380) [[3]](diffhunk://#diff-77b7434a8bec88942a8a10086461663f21b056a44c31c997aed6c4e0a642816aR288) [[4]](diffhunk://#diff-77b7434a8bec88942a8a10086461663f21b056a44c31c997aed6c4e0a642816aL301-R303) [[5]](diffhunk://#diff-77b7434a8bec88942a8a10086461663f21b056a44c31c997aed6c4e0a642816aL341-R344)

**Core LLM Message Formatting**
* Enhanced `add_message` in `mllm.py` to support `image_url` as a preferred method for providing images to LLMs, with logic for different providers (OpenAI, Anthropic, etc.), and updated docstrings for clarity. [[1]](diffhunk://#diff-96830043d291a8546360cb44c52b686dbb10938ee2dcd7868e912835580b4715R225-R239) [[2]](diffhunk://#diff-96830043d291a8546360cb44c52b686dbb10938ee2dcd7868e912835580b4715L266-R299) [[3]](diffhunk://#diff-96830043d291a8546360cb44c52b686dbb10938ee2dcd7868e912835580b4715L317-R373) [[4]](diffhunk://#diff-96830043d291a8546360cb44c52b686dbb10938ee2dcd7868e912835580b4715L364-R439)

**Tool Invocation**
* Updated the tool interface (`tools.py`) to forward `img_url` to the LLM agent when constructing messages, ensuring the screenshot URL is used if available.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.

**Special notes for your reviewer**:
